### PR TITLE
Add CentOS CI build script and Dockerfiles

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,32 @@
+FROM centos:7
+MAINTAINER Vasek Pavlin <vasek@redhat.com>
+
+VOLUME ['/target']
+CMD ['/usr/bin/bash']
+ENV USER_NAME forge
+ENV HOME /home/${USER_NAME}
+
+RUN yum -y install git java java-devel which &&\
+    yum clean all
+
+#FIXME by using scl https://bugzilla.redhat.com/show_bug.cgi?id=1402447
+RUN curl -O http://www.eu.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz &&\
+    tar xzf apache-maven-3.3.9-bin.tar.gz &&\
+    rm -f apache-maven-3.3.9-bin.tar.gz &&\
+    mkdir /usr/local/maven &&\
+    mv apache-maven-3.3.9/ /usr/local/maven/ &&\
+    alternatives --install /usr/bin/mvn mvn /usr/local/maven/apache-maven-3.3.9/bin/mvn 1 &&\
+    alternatives --set mvn /usr/local/maven/apache-maven-3.3.9/bin/mvn
+
+ENV JAVA_HOME /usr/lib/jvm/java-openjdk
+
+RUN useradd --user-group --create-home --shell /bin/false ${USER_NAME}
+
+USER ${USER_NAME}
+WORKDIR ${HOME}
+
+RUN git clone https://github.com/obsidian-toaster/obsidian-addon/ &&\
+    cd obsidian-addon &&\
+    mvn clean install
+
+COPY . ./

--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,0 +1,11 @@
+FROM registry.centos.org/jboss/base-jdk:8
+MAINTAINER Vasek Pavlin <vasek@redhat.com>
+
+EXPOSE 8080
+EXPOSE 8443
+
+CMD ["java", "-jar", "generator-swarm.jar"]
+
+
+COPY target/generator-swarm.jar ./
+

--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/bash
+
+
+REGISTRY_URI="registry.ci.centos.org:5000"
+REGISTRY_NS="obsidian"
+REGISTRY_IMAGE="obsidian-backend:latest"
+RESITRY_URL=${REGISTRY_URI}/${REGISTRY_NS}/${REGISTRY_IMAGE}
+BUILDER_IMAGE="obsidian-backend-builder"
+BUILDER_CONT="obsidian-backend-builder-container"
+DEPLOY_IMAGE="obsidian-backend-deploy"
+
+TARGET_DIR="target"
+
+# Show command before executing
+set -x
+
+# Exit on error
+set -e
+
+if [ -z $CICO_LOCAL ]; then
+    # We need to disable selinux for now, XXX
+    /usr/sbin/setenforce 0
+
+    # Get all the deps in
+    yum -y install docker make git
+
+    # Get all the deps in
+    yum -y install docker make git
+    sed -i '/OPTIONS=.*/c\OPTIONS="--selinux-enabled --log-driver=journald --insecure-registry '${REGISTRY_URI}'"' /etc/sysconfig/docker
+    service docker start
+fi
+
+#CLEAN
+docker ps | grep -q ${BUILDER_CONT} && docker stop ${BUILDER_CONT}
+docker ps -a | grep -q ${BUILDER_CONT} && docker rm ${BUILDER_CONT}
+rm -rf ${TARGET_DIR}/
+
+#BUILD
+docker build -t ${BUILDER_IMAGE} -f Dockerfile.build .
+
+mkdir ${TARGET_DIR}/
+docker run --detach=true --name ${BUILDER_CONT} -t -v $(pwd)/${TARGET_DIR}:/${TARGET_DIR}:Z ${BUILDER_IMAGE} /bin/tail -f /dev/null #FIXME
+
+docker exec ${BUILDER_CONT} mvn clean install
+docker exec -u root ${BUILDER_CONT} cp ${TARGET_DIR}/generator-swarm.jar /${TARGET_DIR}
+
+#BUILD DEPLOY IMAGE
+docker build -t ${DEPLOY_IMAGE} -f Dockerfile.deploy .
+
+#PUSH
+if [ -z $CICO_LOCAL ]; then
+    docker tag ${DEPLOY_IMAGE} ${REGISTRY_URL}
+    docker push ${REGISTRY_URL}
+fi


### PR DESCRIPTION
This PR let's us build generator-backend in CentOS CI (once we add it to https://github.com/almighty/almighty-jobs/blob/master/devtools-ci-index.yaml) 

Right now it pushes only to registry.ci.centos.org, Docker Hub can/will be added later.