### PR TITLE
Fix the home directory permissions for OpenShift user

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -6,6 +6,10 @@ EXPOSE 8443
 
 CMD ["java", "-jar", "generator-swarm.jar"]
 
+USER root
+RUN chgrp -R 0 $HOME &&\
+    chmod -R g+r $HOME &&\
+    find $HOME -type d -exec chmod g+x {} +
+USER jboss
 
 COPY target/generator-swarm.jar ./
-


### PR DESCRIPTION
The container fails to start in OpenShift due to random uid assigned by OpenShift. Lines in this PR should fix it based on 

https://docs.openshift.com/enterprise/3.1/creating_images/guidelines.html#openshift-enterprise-specific-guidelines