### PR TITLE
refactor to allow more flexible exposing of commands, mapping of commands to zip downloads and to allow optional query commands to be exposed over a nicer GET REST API

### DIFF
--- a/src/main/java/org/obsidiantoaster/generator/rest/ExposedCommands.java
+++ b/src/main/java/org/obsidiantoaster/generator/rest/ExposedCommands.java
@@ -1,0 +1,123 @@
+/**
+ *  Copyright 2005-2015 Red Hat, Inc.
+ *
+ *  Red Hat licenses this file to you under the Apache License, version
+ *  2.0 (the "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ *  implied.  See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+package org.obsidiantoaster.generator.rest;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ */
+public class ExposedCommands
+{
+   private final Map<String, String> commandMap = new TreeMap<>();
+   private final Map<String, String> queryMap = new TreeMap<>();
+   private final Set<String> zipCommands = new HashSet<>();
+
+   public ExposedCommands()
+   {
+      addZipCommand("obsidian-new-quickstart", "Obsidian: New Quickstart");
+      addZipCommand("obsidian-new-project", "Obsidian: New Project");
+   }
+
+   /**
+    * Returns the commands which are allowed to be exported over the REST API via POST
+    */
+   public Map<String, String> getAllowedCommands()
+   {
+      return commandMap;
+   }
+
+   /**
+    * Returns the queries which are allowed to be exported over the REST API via GET
+    */
+   public Map<String, String> getAllowedQueries()
+   {
+      return queryMap;
+   }
+
+   /**
+    * Returns true if the command should generate a zip file as part of the execution result
+    */
+   public boolean generateZipCommand(String commandName)
+   {
+      return zipCommands.contains(commandName);
+   }
+
+   /**
+    * Returns the label of the given command name or null if it is not supported
+    */
+   public String getCommandLabel(String name)
+   {
+      return commandMap.get(name);
+   }
+
+   /**
+    * Validates the command name is valid
+    */
+   public void validateCommand(String name) {
+      if (commandMap.get(name) == null) {
+         String message;
+         if (commandMap.isEmpty()) {
+            message = "No commands are supported by this service";
+         } else
+         {
+            message = "No such command `" + name + "`. Supported commmands are '" + String
+                     .join("', '", commandMap.keySet()) + "'";
+         }
+         throw new WebApplicationException(message, Response.Status.NOT_FOUND);
+      }
+   }
+
+
+   /**
+    * Validates the query name is valid
+    */
+   public void validateQuery(String name) {
+      if (queryMap.get(name) == null) {
+         String message;
+         if (queryMap.isEmpty()) {
+            message = "No queries are supported by this service";
+         } else
+         {
+            message = "No such query `" + name + "`. Supported queries are '" + String
+                     .join("', '", queryMap.keySet()) + "'";
+         }
+         throw new WebApplicationException(message, Response.Status.NOT_FOUND);
+      }
+   }
+
+
+   protected void addQuery(String name, String label)
+   {
+      queryMap.put(name, label);
+      addCommand(name, label);
+   }
+
+   protected void addCommand(String name, String label)
+   {
+      commandMap.put(name, label);
+   }
+
+   protected void addZipCommand(String name, String label)
+   {
+      addCommand(name, label);
+      zipCommands.add(name);
+   }
+}

--- a/src/main/java/org/obsidiantoaster/generator/rest/ExposedCommands.java
+++ b/src/main/java/org/obsidiantoaster/generator/rest/ExposedCommands.java
@@ -17,10 +17,10 @@ package org.obsidiantoaster.generator.rest;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  */
@@ -28,7 +28,7 @@ public class ExposedCommands
 {
    private final Map<String, String> commandMap = new TreeMap<>();
    private final Map<String, String> queryMap = new TreeMap<>();
-   private final Set<String> zipCommands = new HashSet<>();
+   private final Set<String> zipCommands = new TreeSet<>();
 
    public ExposedCommands()
    {
@@ -78,11 +78,30 @@ public class ExposedCommands
             message = "No commands are supported by this service";
          } else
          {
-            message = "No such command `" + name + "`. Supported commmands are '" + String
+            message = "No such command `" + name + "`. Supported commands are '" + String
                      .join("', '", commandMap.keySet()) + "'";
          }
          throw new WebApplicationException(message, Response.Status.NOT_FOUND);
       }
+   }
+
+   /**
+    * Validates the command name can generate a zip
+    */
+   public void validateZipCommand(String name)
+   {
+      if (!zipCommands.contains(name)) {
+         String message;
+         if (zipCommands.isEmpty()) {
+            message = "No commands can generate zips in this service";
+         } else
+         {
+            message = "No such zip command `" + name + "`. Supported zip commands are '" + String
+                     .join("', '", zipCommands) + "'";
+         }
+         throw new WebApplicationException(message, Response.Status.NOT_FOUND);
+      }
+
    }
 
 
@@ -120,4 +139,5 @@ public class ExposedCommands
       addCommand(name, label);
       zipCommands.add(name);
    }
+
 }

--- a/src/main/java/org/obsidiantoaster/generator/rest/ObsidianResource.java
+++ b/src/main/java/org/obsidiantoaster/generator/rest/ObsidianResource.java
@@ -231,7 +231,7 @@ public class ObsidianResource
             @Context HttpHeaders headers)
             throws Exception
    {
-      exposedCommands.validateCommand(commandName);
+      exposedCommands.validateQuery(commandName);
       String stepIndex = null;
       MultivaluedMap<String, String> parameters = uriInfo.getQueryParameters();
       List<String> stepValues = parameters.get("stepIndex");
@@ -252,7 +252,7 @@ public class ObsidianResource
          }
       }
 
-      final Response response = downloadZip(jsonBuilder.build(), commandName, headers);
+      final Response response = executeCommandJson(jsonBuilder.build(), commandName, headers);
       if (response.getEntity() instanceof JsonObject)
       {
          JsonObject responseEntity = (JsonObject) response.getEntity();
@@ -286,7 +286,7 @@ public class ObsidianResource
          jsonBuilder.addInput(entry.getKey(), entry.getValue());
       }
 
-      final Response response = downloadZip(jsonBuilder.build(), commandName, headers);
+      final Response response = executeCommandJson(jsonBuilder.build(), commandName, headers);
       if (response.getEntity() instanceof JsonObject)
       {
          JsonObject responseEntity = (JsonObject) response.getEntity();

--- a/src/main/java/org/obsidiantoaster/generator/rest/ObsidianResource.java
+++ b/src/main/java/org/obsidiantoaster/generator/rest/ObsidianResource.java
@@ -409,7 +409,7 @@ public class ObsidianResource
          }
          return answer;
       }
-      return result.getEntity().get();
+      return result.getEntity().orElse(null);
    }
 
    /**

--- a/src/main/java/org/obsidiantoaster/generator/rest/ObsidianResource.java
+++ b/src/main/java/org/obsidiantoaster/generator/rest/ObsidianResource.java
@@ -334,9 +334,9 @@ public class ObsidianResource
                }
                else {
                   String entity = getMessage(result);
-                  String contentType = "plain/text";
+                  String contentType = MediaType.TEXT_PLAIN;
                   if (isJsonString(entity)) {
-                     contentType = "application/json";
+                     contentType = MediaType.APPLICATION_JSON;
                   }
                   return Response
                            .ok(entity)

--- a/src/main/java/org/obsidiantoaster/generator/rest/ObsidianResource.java
+++ b/src/main/java/org/obsidiantoaster/generator/rest/ObsidianResource.java
@@ -39,6 +39,7 @@ import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
+import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonString;
@@ -311,7 +312,9 @@ public class ObsidianResource
             Result result = controller.execute();
             if (result instanceof Failed)
             {
-               return Response.status(Status.INTERNAL_SERVER_ERROR).entity(getMessage(result)).build();
+               JsonObjectBuilder builder = Json.createObjectBuilder();
+               helper.describeResult(builder,result);
+               return Response.status(Status.INTERNAL_SERVER_ERROR).entity(builder).build();
             }
             else
             {


### PR DESCRIPTION
its often handy when creating front end UIs to be able to query forge commands for information; such as what git accounts are setup, what project types are there (if you wanted to create a front screen before the actual wizard that pre-selects the project type) or whatever.

So this refactor makes it easy to expose a subset of commands as idempotent queries via GET with query arguments. 

It also makes it easy to configure which commands generate zips and which don't. This refactor should also make it easier to plugin different kinds of REST commands in a more modular fashion. 

BTW here's an example of a 'query command':
https://github.com/fabric8io/fabric8-generator/blob/master/src/main/java/io/fabric8/forge/generator/git/CheckGitAccounts.java#L47

notice that it can be used like any other forge command inside the CLI / IDE. But then when using the REST API we can query the result as JSON easily which is very handy.

BTW it might be nice one day to automate the setting of `format` to JSON if the `Accept` header is set to `application/json`