### PR TITLE
Remove set -x

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -12,9 +12,6 @@ DEPLOY_IMAGE="obsidian-generator-backend-deploy"
 
 TARGET_DIR="target"
 
-# Show command before executing
-set -x
-
 # Exit on error
 set -e
 


### PR DESCRIPTION
`set -x` prints variables end their values when a file is sourced, which could expose credentials through logs.