### PR TITLE
Makes tests client-side only + updates to latest arq-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
       <catalog.repository>https://github.com/openshiftio/booster-catalog</catalog.repository>
       <failOnMissingWebXml>false</failOnMissingWebXml>
       <!-- Versions -->
-      <arquillian.version>1.1.12.Final</arquillian.version>
+      <arquillian.version>1.1.13.Final</arquillian.version>
       <launchpad.addon.version>14-SNAPSHOT</launchpad.addon.version>
       <fabric8.maven.plugin.version>3.1.92</fabric8.maven.plugin.version>
       <wildfly.swarm.version>2017.8.1</wildfly.swarm.version>

--- a/src/test/java/io/openshift/launchpad/backend/rest/HealthResourceIT.java
+++ b/src/test/java/io/openshift/launchpad/backend/rest/HealthResourceIT.java
@@ -15,12 +15,8 @@
  */
 package io.openshift.launchpad.backend.rest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.StringReader;
 import java.net.URI;
-
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.ws.rs.client.Client;
@@ -28,9 +24,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
-
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
@@ -39,13 +33,16 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 /**
  *
  */
 @RunWith(Arquillian.class)
 public class HealthResourceIT
 {
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createDeployment()
    {
       return Deployments.createDeployment();
@@ -65,7 +62,6 @@ public class HealthResourceIT
    }
 
    @Test
-   @RunAsClient
    public void readinessCheck()
    {
       final Response response = readyTarget.request().get();
@@ -80,7 +76,6 @@ public class HealthResourceIT
 
    @Ignore("Until we can run the test against an actual Mission Control instance")
    @Test
-   @RunAsClient
    public void catapultReadinessCheck() throws Exception
    {
       URI catapultServiceURI = HealthResource.createMissionControlUri();

--- a/src/test/java/io/openshift/launchpad/backend/rest/LaunchResourceIT.java
+++ b/src/test/java/io/openshift/launchpad/backend/rest/LaunchResourceIT.java
@@ -15,13 +15,9 @@
  */
 package io.openshift.launchpad.backend.rest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
+import io.openshift.launchpad.backend.util.JsonBuilder;
 import java.io.StringReader;
 import java.net.URI;
-
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.ws.rs.client.Client;
@@ -30,9 +26,7 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
-
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.Archive;
@@ -40,7 +34,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.openshift.launchpad.backend.util.JsonBuilder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -48,7 +44,7 @@ import io.openshift.launchpad.backend.util.JsonBuilder;
 @RunWith(Arquillian.class)
 public class LaunchResourceIT
 {
-   @Deployment
+   @Deployment(testable = false)
    public static Archive<?> createDeployment()
    {
       return Deployments.createDeployment();
@@ -68,7 +64,6 @@ public class LaunchResourceIT
    }
 
    @Test
-   @RunAsClient
    public void shouldRespondWithVersion()
    {
       final Response response = webTarget.path("/version").request().get();
@@ -79,7 +74,6 @@ public class LaunchResourceIT
    }
 
    @Test
-   @RunAsClient
    public void shouldGoToNextStep()
    {
       final JsonObject jsonObject = new JsonBuilder().createJson(1)


### PR DESCRIPTION
With `@Deployment(testable = false)` all tests are executed as-client and none of Arquillian extensions are deployed together with application war. This makes it a bit leaner and closer to the reality. Also fits better REST tests which are blackbox.