### PR TITLE
Altering CMD to pass JAVA_OPTS to wildfly

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -4,7 +4,7 @@ MAINTAINER Vasek Pavlin <vasek@redhat.com>
 EXPOSE 8080
 EXPOSE 8443
 
-CMD ["java", "-jar", "launchpad-backend-swarm.jar"]
+CMD ["sh", "-c", "java $JAVA_OPTS -jar launchpad-backend-swarm.jar"]
 
 USER root
 RUN chgrp -R 0 /opt/jboss &&\


### PR DESCRIPTION
I run OpenShift on Debian and IPv6 doesn't appear in the pod correctly and prevents it from starting.  However, I can pass a Java opt to prefer IPv4 address which makes the pod start normally.  I have edited the Dockerfile.deploy to allow the JAVA_OPTS variable to be respected.